### PR TITLE
setting request wrapper to false by default. don't throw an error if …

### DIFF
--- a/config/agent.yml
+++ b/config/agent.yml
@@ -15,7 +15,7 @@ actionMailerEnabled: true #NETUITIVE_RAILS_ACTION_MAILER_ENABLED
 activeSupportEnabled: true #NETUITIVE_RAILS_ACTIVE_SUPPORT_ENABLED
 activeJobEnabled: true #NETUITIVE_RAILS_ACTIVE_JOB_ENABLED
 #injected instrumentation
-requestWrapperEnabled: true #NETUITIVE_RAILS_REQUEST_WRAPPER_ENABLED
+requestWrapperEnabled: false #NETUITIVE_RAILS_REQUEST_WRAPPER_ENABLED
 actionErrorsEnabled: true #NETUITIVE_RAILS_ACTION_ERRORS_ENABLED
 #interpreter metrics
 gcEnabled: true #NETUITIVE_RAILS_GC_ENABLED

--- a/lib/netuitive_rails_agent/request_data.rb
+++ b/lib/netuitive_rails_agent/request_data.rb
@@ -24,6 +24,7 @@ module NetuitiveRailsAgent
           start_time = start_time.nil? || header_time < start_time ? header_time : start_time
           NetuitiveRailsAgent::NetuitiveLogger.log.debug "queue start_time: #{start_time}"
         end
+        return nil if start_time.nil?
         return (Time.now.to_f - start_time) * 1000.0
       end
       nil
@@ -33,6 +34,10 @@ module NetuitiveRailsAgent
       return unless request
       begin
         queue_time = NetuitiveRailsAgent::RequestDataHook.header_start_time(request.headers)
+        if queue_time.nil?
+          NetuitiveRailsAgent::NetuitiveLogger.log.info 'no queue time header found for request'
+          return
+        end
         NetuitiveRailsAgent::NetuitiveLogger.log.debug "queue_time: #{queue_time}"
         NetuitiveRailsAgent::NetuitiveLogger.log.debug 'sending queue_time metrics'
         NetuitiveRubyAPI.add_sample('action_controller.request.queue_time', queue_time)


### PR DESCRIPTION
…we don't have the request time header
